### PR TITLE
Perform fully recursive serialization of ItemStacks. Fixes #39

### DIFF
--- a/src/main/java/tk/manf/InventorySQL/database/handler/MySQLDatabaseHandler.java
+++ b/src/main/java/tk/manf/InventorySQL/database/handler/MySQLDatabaseHandler.java
@@ -31,7 +31,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.zip.DataFormatException;
 import lombok.Cleanup;
 import lombok.SneakyThrows;
 import org.bukkit.entity.Player;
@@ -92,7 +91,7 @@ public class MySQLDatabaseHandler implements DatabaseHandler {
         stmt.close();
     }
 
-    private ItemStack[][] getPlayerInventory(String playername) throws SQLException, DataFormatException, DataHandlingException {
+    private ItemStack[][] getPlayerInventory(String playername) throws SQLException, DataHandlingException {
         Connection con = getConnection();
         @Cleanup
         PreparedStatement stmt = con.prepareStatement(GET_PLAYER_INVENTORY_DATA_QUERY);


### PR DESCRIPTION
This fixes ticket #39 by serializing the Color inside of LeatherArmorMeta, as seen in this stacktrace excerpt:

```
22:24:42 [SEVERE] Could not call method 'public static org.bukkit.inventory.meta.ItemMeta
org.bukkit.craftbukkit.v1_6_R2.inventory.CraftMetaItem$SerializableMeta.deserialize(java.util.Map)
throws java.lang.Throwable' of class org.bukkit.craftbukkit.v1_6_R2.inventory.CraftMetaItem$SerializableMeta
for deserialization

java.lang.IllegalArgumentException: color({red=25, green=25, blue=25}) is not a valid class org.bukkit.Color
```

We may want to also provide a new Serializer using the BukkitObjectOutputStream that Wolvereness recently committed.
